### PR TITLE
Add contact frequency field and improve form UX

### DIFF
--- a/src/components/AdvisorForm.tsx
+++ b/src/components/AdvisorForm.tsx
@@ -72,6 +72,7 @@ export function AdvisorForm({ onComplete }: AdvisorFormProps) {
         contactName: contactData.name,
         contactDesignation: contactData.designation,
         relationshipStrength: contactData.relationshipStrength,
+        contactFrequency: contactData.contactFrequency,
         timestamp: new Date()
       };
 

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -20,7 +20,8 @@ export function ContactForm({
   const [formData, setFormData] = useState<ContactFormData>({
     name: '',
     designation: '',
-    relationshipStrength: ''
+    relationshipStrength: '',
+    contactFrequency: ''
   });
 
   const [errors, setErrors] = useState<Partial<Record<keyof ContactFormData, string>>>({});
@@ -30,6 +31,10 @@ export function ContactForm({
 
     if (!formData.relationshipStrength) {
       newErrors.relationshipStrength = 'Please select relationship strength';
+    }
+
+    if (!formData.contactFrequency) {
+      newErrors.contactFrequency = 'Please select contact frequency';
     }
 
     if (!formData.name || !formData.name.trim()) {
@@ -61,7 +66,7 @@ export function ContactForm({
     }
   };
 
-  const handleSelectChange = (value: string | string[]) => {
+  const handleRelationshipChange = (value: string | string[]) => {
     setFormData(prev => ({
       ...prev,
       relationshipStrength: value as ContactFormData['relationshipStrength']
@@ -72,6 +77,21 @@ export function ContactForm({
       setErrors(prev => ({
         ...prev,
         relationshipStrength: undefined
+      }));
+    }
+  };
+
+  const handleFrequencyChange = (value: string | string[]) => {
+    setFormData(prev => ({
+      ...prev,
+      contactFrequency: value as ContactFormData['contactFrequency']
+    }));
+
+    // Clear error when user selects
+    if (errors.contactFrequency) {
+      setErrors(prev => ({
+        ...prev,
+        contactFrequency: undefined
       }));
     }
   };
@@ -89,7 +109,7 @@ export function ContactForm({
   };
 
   const handleCancel = () => {
-    setFormData({ name: '', designation: '', relationshipStrength: '' });
+    setFormData({ name: '', designation: '', relationshipStrength: '', contactFrequency: '' });
     setErrors({});
     onCancel();
   };
@@ -112,7 +132,7 @@ export function ContactForm({
             name="relationshipStrength"
             label="How strong is your relationship?"
             value={formData.relationshipStrength}
-            onChange={handleSelectChange}
+            onChange={handleRelationshipChange}
             options={[
               { value: 'very-strong', label: 'Very strong' },
               { value: 'strong', label: 'Strong' },
@@ -124,6 +144,27 @@ export function ContactForm({
             disabled={loading}
             size="large"
             placeholder="Select relationship strength..."
+          />
+        </div>
+
+        <div>
+          <Select
+            id="contact-frequency"
+            name="contactFrequency"
+            label="How often are you in touch with your contact?"
+            value={formData.contactFrequency}
+            onChange={handleFrequencyChange}
+            options={[
+              { value: 'quarterly', label: 'Quarterly' },
+              { value: 'annually', label: 'Annually' },
+              { value: 'occasionally', label: 'Occasionally' },
+              { value: 'recently', label: 'Recently' }
+            ]}
+            error={errors.contactFrequency}
+            required
+            disabled={loading}
+            size="large"
+            placeholder="Select contact frequency..."
           />
         </div>
 

--- a/src/components/FirmInput.tsx
+++ b/src/components/FirmInput.tsx
@@ -169,7 +169,7 @@ export function FirmInput({
         </div>
 
         <Button
-          appearance="primary"
+          appearance="secondary"
           size="large"
           onClick={handleSubmitClick}
           disabled={disabled || !value.trim()}

--- a/src/components/FirmInputStep.tsx
+++ b/src/components/FirmInputStep.tsx
@@ -83,7 +83,7 @@ export function FirmInputStep({
           {enteredFirms.length > 0 && (
             <div className="pt-4">
               <Button
-                appearance="secondary"
+                appearance="primary"
                 size="large"
                 onClick={onFinish}
                 className="w-full"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,10 +22,13 @@ export default function HomePage() {
             <h1 className="text-5xl font-bold text-night-sky-blue-dark-1 leading-tight">
               Network Assist Portal
             </h1>
+            <p className="text-neutral-1 max-w-xl mx-auto text-lg">
+              Please indicate the firms where you have strong relationships and would be willing to make an introduction. For each firm that matches our prospect list, we'll ask you to share contact details.
+            </p>
           </div>
 
           {/* Form */}
-          <div className="max-w-md mx-auto">
+          <div className="max-w-xl mx-auto">
             <AdvisorForm onComplete={handleFormComplete} />
           </div>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface FirmEntry {
   contactName?: string;
   contactDesignation?: string;
   relationshipStrength?: 'very-strong' | 'strong' | 'moderate' | 'weak' | '';
+  contactFrequency?: 'quarterly' | 'annually' | 'occasionally' | 'recently' | '';
   timestamp: Date;
 }
 
@@ -70,4 +71,5 @@ export interface ContactFormData {
   name: string;
   designation: string;
   relationshipStrength: 'very-strong' | 'strong' | 'moderate' | 'weak' | '';
+  contactFrequency: 'quarterly' | 'annually' | 'occasionally' | 'recently' | '';
 }


### PR DESCRIPTION
## Summary
- Added contact frequency field to the contact details form with options: Quarterly, Annually, Occasionally, Recently
- Added introductory paragraph explaining the form's purpose on the home page
- Improved button visual hierarchy (Add Firm → secondary, Finish → primary)
- Increased form width to match the introductory text width for better visual alignment

## Changes

### New Contact Frequency Field
- Added "How often are you in touch with your contact?" field after relationship strength selection
- Field is required and includes validation
- Updated TypeScript types to support the new `contactFrequency` field in both `FirmEntry` and `ContactFormData` interfaces

### UX Improvements
- Added descriptive paragraph below the "Network Assist Portal" heading to explain the form's purpose
- Changed "Add Firm" button from primary to secondary appearance
- Changed "Finish" button from secondary to primary appearance  
- Widened form container from `max-w-md` to `max-w-xl` to match paragraph width

## Test Plan
- [ ] Verify contact frequency field appears in the contact details form after matching a firm
- [ ] Test all four frequency options can be selected: Quarterly, Annually, Occasionally, Recently
- [ ] Confirm validation error appears if frequency is not selected
- [ ] Verify form data includes contact frequency when submitted
- [ ] Check that introductory paragraph displays correctly on home page
- [ ] Confirm button styling matches new visual hierarchy
- [ ] Verify form width matches paragraph width

🤖 Generated with [Claude Code](https://claude.com/claude-code)