### PR TITLE
Add Slack integration for form submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
@@ -22,3 +25,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,18 @@
+[build]
+  publish = "dist"
+  command = "npm run build"
+
+[dev]
+  command = "npm run dev"
+  targetPort = 5173
+  port = 8888
+
+[functions]
+  directory = "netlify/functions"
+
+[[headers]]
+  for = "/.netlify/functions/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Headers = "Content-Type"
+    Access-Control-Allow-Methods = "GET, POST, OPTIONS"

--- a/netlify/functions/submit-form.js
+++ b/netlify/functions/submit-form.js
@@ -1,0 +1,209 @@
+export const handler = async (event, context) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS'
+      },
+      body: JSON.stringify({ error: 'Method not allowed' })
+    };
+  }
+
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS'
+      },
+      body: ''
+    };
+  }
+
+  try {
+    const formData = JSON.parse(event.body);
+
+    const { firms, userEmail } = formData;
+
+    if (!firms || !Array.isArray(firms) || firms.length === 0) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        },
+        body: JSON.stringify({ error: 'Missing required fields' })
+      };
+    }
+
+    // Build firm details blocks
+    const firmBlocks = firms.flatMap((firm, index) => {
+      const fields = [
+        {
+          type: "mrkdwn",
+          text: `*Firm Name:*\n${firm.firmName}`
+        },
+        {
+          type: "mrkdwn",
+          text: `*Status:*\n${firm.isMatched ? '✅ Matched' : '❌ Not Matched'}`
+        }
+      ];
+
+      // Add contact details if firm is matched
+      if (firm.isMatched && firm.contactName) {
+        fields.push(
+          {
+            type: "mrkdwn",
+            text: `*Contact Name:*\n${firm.contactName}`
+          },
+          {
+            type: "mrkdwn",
+            text: `*Designation:*\n${firm.contactDesignation || 'Not specified'}`
+          },
+          {
+            type: "mrkdwn",
+            text: `*Relationship:*\n${formatRelationshipStrength(firm.relationshipStrength)}`
+          },
+          {
+            type: "mrkdwn",
+            text: `*Contact Frequency:*\n${formatContactFrequency(firm.contactFrequency)}`
+          }
+        );
+      }
+
+      return [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Firm ${index + 1}:*`
+          }
+        },
+        {
+          type: "section",
+          fields: fields
+        },
+        {
+          type: "divider"
+        }
+      ];
+    });
+
+    const slackMessage = {
+      text: "New Network Assist Form Submission",
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "🆕 New Network Assist Form Submission"
+          }
+        },
+        {
+          type: "section",
+          fields: [
+            {
+              type: "mrkdwn",
+              text: `*User Email:*\n${userEmail || 'Not provided'}`
+            },
+            {
+              type: "mrkdwn",
+              text: `*Total Firms:*\n${firms.length}`
+            }
+          ]
+        },
+        {
+          type: "divider"
+        },
+        ...firmBlocks,
+        {
+          type: "context",
+          elements: [
+            {
+              type: "plain_text",
+              text: `Submitted on ${new Date().toLocaleString()}`
+            }
+          ]
+        }
+      ]
+    };
+
+    const webhookUrl = process.env.WEBHOOK_URL;
+
+    if (!webhookUrl) {
+      console.error('WEBHOOK_URL environment variable not set');
+      return {
+        statusCode: 500,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        },
+        body: JSON.stringify({ error: 'Server configuration error' })
+      };
+    }
+
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(slackMessage)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Slack webhook failed: ${response.status}`);
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*'
+      },
+      body: JSON.stringify({
+        success: true,
+        message: 'Form submitted successfully!'
+      })
+    };
+
+  } catch (error) {
+    console.error('Function error:', error);
+
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*'
+      },
+      body: JSON.stringify({
+        error: 'Internal server error',
+        message: 'Failed to process form submission'
+      })
+    };
+  }
+};
+
+// Helper functions to format enum values
+function formatRelationshipStrength(value) {
+  const mapping = {
+    'very-strong': 'Very Strong',
+    'strong': 'Strong',
+    'moderate': 'Moderate',
+    'weak': 'Weak'
+  };
+  return mapping[value] || 'Not specified';
+}
+
+function formatContactFrequency(value) {
+  const mapping = {
+    'quarterly': 'Quarterly',
+    'annually': 'Annually',
+    'occasionally': 'Occasionally',
+    'recently': 'Recently'
+  };
+  return mapping[value] || 'Not specified';
+}


### PR DESCRIPTION
## Summary
- Integrated Slack notifications for Network Assist form submissions
- Added Netlify serverless function to handle form data and send formatted messages to Slack
- Configured environment variables for secure webhook URL management

## Changes

### New Files
- **netlify.toml** - Netlify configuration with build settings, dev server config, and CORS headers
- **netlify/functions/submit-form.js** - Serverless function that formats form data and posts to Slack webhook
- **.env.example** - Template for required environment variables

### Modified Files
- **src/components/AdvisorForm.tsx** - Updated `handleFinish` to call Netlify function with all firm entries and user email
- **.gitignore** - Added `.env` and `.netlify` folder to ignored files

### Slack Message Format
The Slack notification includes:
- Header with submission indicator
- User email and total firms count
- For each firm:
  - Firm name and match status (✅ matched / ❌ not matched)
  - Contact details (name, designation, relationship strength, contact frequency) for matched firms
- Submission timestamp

### Environment Setup
Requires `WEBHOOK_URL` environment variable containing the Slack incoming webhook URL. Set this in:
- `.env` file for local development
- Netlify dashboard → Site Settings → Environment Variables for production

## Test Plan
- [ ] Verify local testing works with `netlify dev`
- [ ] Submit a form with matched firms and verify Slack message appears with complete contact details
- [ ] Submit a form with unmatched firms and verify they appear without contact details
- [ ] Test with multiple firms (up to 5) to ensure all are included in notification
- [ ] Verify form completion screen still appears even if Slack notification fails
- [ ] Confirm user email displays correctly in Slack message

🤖 Generated with [Claude Code](https://claude.com/claude-code)